### PR TITLE
fix: Wayland workaround on GNOME with extension

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -87,7 +87,15 @@ function __done_get_focused_window_id
     else if begin
             test "$XDG_SESSION_DESKTOP" = gnome; and type -q gdbus
         end
-        gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell --method org.gnome.Shell.Eval 'global.display.focus_window.get_id()'
+
+        if test "$XDG_SESSION_TYPE" = wayland
+            and type -q gnome-extensions
+            and gnome-extensions info -q focused-window-dbus@flexagoon.com >/dev/null 2>&1
+            gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/shell/extensions/FocusedWindow --method org.gnome.shell.extensions.FocusedWindow.Get \
+                | grep -Eo '"id":[[:digit:]]+,' | grep -Eo '[[:digit:]]+'
+        else
+            gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell --method org.gnome.Shell.Eval 'global.display.focus_window.get_id()'
+        end
     else if type -q xprop
         and test -n "$DISPLAY"
         # Test that the X server at $DISPLAY is running


### PR DESCRIPTION
https://github.com/flexagoon/focused-window-dbus
If GNOME extension "Focused Window D-Bus" is installed, use it to get id of focused window.